### PR TITLE
Fixing bug with repository name in validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,4 @@ jobs:
         uses: ./
         with:
           version: "0.0.1"
-          release_notes_file: "tests/0.0.1.md"
+          releaseNotesDirectory: "tests"

--- a/action.yml
+++ b/action.yml
@@ -41,8 +41,8 @@ runs:
     - name: Validate Formatting
       shell: bash
       run: |
-        if ! grep -q "^# \[${{ inputs.version }}\](https://github.com/cloudzero/cloudzero-changelog-release-notes/compare/.*) ([0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\})" ${{ steps.set-path.outputs.file_path }}; then
-            echo "Error: Version ${{ inputs.version }} does not have the correct title format \"# [${{ inputs.version }}](https://github.com/cloudzero/cloudzero-changelog-release-notes/compare/) - YYYY-MM-DD\""
+        if ! grep -q "^# \[${{ inputs.version }}\](https://github.com/${{ github.repository }}/compare/.*) ([0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\})" ${{ steps.set-path.outputs.file_path }}; then
+            echo "Error: Version ${{ inputs.version }} does not have the correct title format \"# [${{ inputs.version }}](https://github.com/${{ github.repository }}/compare/) - YYYY-MM-DD\""
             exit 1
         fi
     

--- a/docs/releases/0.0.1.md
+++ b/docs/releases/0.0.1.md
@@ -1,4 +1,4 @@
-# [0.0.1](https://github.com/cloudzero/cloudzero-changelog-release-notes/compare/6f2f4723a345a656115168cf46e37e145bba2a35...0.0.1) (2024-11-14)
+# [0.0.1](https://github.com/Cloudzero/cloudzero-changelog-release-notes/compare/6f2f4723a345a656115168cf46e37e145bba2a35...0.0.1) (2024-11-14)
 
 > Initial release of the CloudZero Changelog Release Notes Action
 

--- a/docs/releases/1.0.0.md
+++ b/docs/releases/1.0.0.md
@@ -1,4 +1,4 @@
-# [1.0.0](https://github.com/cloudzero/cloudzero-changelog-release-notes/compare/0.0.1...1.0.0) (2024-11-18)
+# [1.0.0](https://github.com/Cloudzero/cloudzero-changelog-release-notes/compare/0.0.1...1.0.0) (2024-11-18)
 
 > Stable release of the CloudZero Changelog Release Notes Action
 

--- a/docs/releases/1.0.1.md
+++ b/docs/releases/1.0.1.md
@@ -1,0 +1,7 @@
+# [1.0.1](https://github.com/cloudzero/cloudzero-changelog-release-notes/compare/1.0.0...1.0.1) (2024-11-19)
+
+> Fixed bug with hardcoded repository name in release notes validation
+
+## Bug Fixes
+
+* **Release Notes Validation:** Fixed bug with hardcoded repository name in release notes validation. Now uses the repository name from the GitHub context.

--- a/docs/releases/1.0.1.md
+++ b/docs/releases/1.0.1.md
@@ -1,4 +1,4 @@
-# [1.0.1](https://github.com/cloudzero/cloudzero-changelog-release-notes/compare/1.0.0...1.0.1) (2024-11-19)
+# [1.0.1](https://github.com/Cloudzero/cloudzero-changelog-release-notes/compare/1.0.0...1.0.1) (2024-11-19)
 
 > Fixed bug with hardcoded repository name in release notes validation
 

--- a/tests/0.0.1.md
+++ b/tests/0.0.1.md
@@ -1,4 +1,4 @@
-# [0.0.1](https://github.com/cloudzero/cloudzero-changelog-release-notes/compare/0.0.1...6f2f4723a345a656115168cf46e37e145bba2a35) (2024-11-14)
+# [0.0.1](https://github.com/Cloudzero/cloudzero-changelog-release-notes/compare/6f2f4723a345a656115168cf46e37e145bba2a35...0.0.1) (2024-11-14)
 
 > Initial release of the CloudZero Changelog Release Notes Action
 


### PR DESCRIPTION
## Description of the change

> Fixing bug with repository name in validation

## Type of change
- [x] Bug fix
- [ ] New feature

## Checklists

### Development
- [x] All changed code has 80% unit test coverage
- [x] All changed code has been automatically (smoke test or otherwise) or manually verified in `alfa` (or with a cross namespace setup, e.g. developer namespace for this feature, pointing at shared `alfa` resources)
